### PR TITLE
Scaling dots to the original zoom ratio

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# IDE0027: Use expression body for accessors
+csharp_style_expression_bodied_accessors = true

--- a/Darwin.sln
+++ b/Darwin.sln
@@ -13,7 +13,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Darwin", "src\Darwin\Darwin
 EndProject
 Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "Darwin.Wpf.Setup", "src\Darwin.Wpf.Setup\Darwin.Wpf.Setup.vdproj", "{B30EF446-8956-4DE2-8DC7-F5AC06C55C66}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Darwin.ML", "src\Darwin.ML\Darwin.ML.csproj", "{0C2BF656-F946-4785-BA90-409838C0EA2D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Darwin.ML", "src\Darwin.ML\Darwin.ML.csproj", "{0C2BF656-F946-4785-BA90-409838C0EA2D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D6016D55-A6FB-4DEB-9E3D-BF385D9A05E7}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Darwin.Wavelet/Darwin.Wavelet.csproj
+++ b/src/Darwin.Wavelet/Darwin.Wavelet.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\.editorconfig" Link=".editorconfig" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Darwin.Utilities\Darwin.Utilities.csproj" />
   </ItemGroup>
 

--- a/src/Darwin.Wpf/FrameworkElements/PointVisuals.cs
+++ b/src/Darwin.Wpf/FrameworkElements/PointVisuals.cs
@@ -115,7 +115,7 @@ namespace Darwin.Wpf.FrameworkElements
         public double PointSize
         {
             set { SetValue(PointSizeProperty, value); }
-            get { return (double)GetValue(PointSizeProperty); }
+            get { return 1.5/(double)GetValue(PointSizeProperty); }
         }
 
         public double FeaturePointSize

--- a/src/Darwin.Wpf/FrameworkElements/PointVisuals.cs
+++ b/src/Darwin.Wpf/FrameworkElements/PointVisuals.cs
@@ -115,7 +115,7 @@ namespace Darwin.Wpf.FrameworkElements
         public double PointSize
         {
             set { SetValue(PointSizeProperty, value); }
-            //GetValue(PointSizeProperty) returns ZoomRatio and uses it as a scale factor for a consistent point size across varied image resolutions
+            //GetValue(PointSizeProperty) returns OriginalZoomRatio and uses it as a scale factor for a consistent point size across varied image resolutions and zoom factors
             get { return 1.5 / (double)GetValue(PointSizeProperty); }
         }
 

--- a/src/Darwin.Wpf/FrameworkElements/PointVisuals.cs
+++ b/src/Darwin.Wpf/FrameworkElements/PointVisuals.cs
@@ -115,7 +115,8 @@ namespace Darwin.Wpf.FrameworkElements
         public double PointSize
         {
             set { SetValue(PointSizeProperty, value); }
-            get { return 1.5/(double)GetValue(PointSizeProperty); }
+            //GetValue(PointSizeProperty) returns ZoomRatio and uses it as a scale factor for a consistent point size across varied image resolutions
+            get { return 1.5 / (double)GetValue(PointSizeProperty); }
         }
 
         public double FeaturePointSize

--- a/src/Darwin.Wpf/MainWindow.xaml
+++ b/src/Darwin.Wpf/MainWindow.xaml
@@ -300,7 +300,7 @@ along with DARWIN.  If not, see https://www.gnu.org/licenses/
                         </TabItem>
                         <TabItem Header="Fin Data" Height="20" VerticalAlignment="Top">
                             <Button x:Name="FinDataButton" Click="FinDataButton_Click" IsEnabled="{Binding Path=SelectedContour, Converter={StaticResource NullConverter}}" Cursor="Hand" Background="Transparent" BorderThickness="0">
-                                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Disabled" Background="Transparent" Height="591" Width="749">
+                                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Disabled" Background="{StaticResource LightBackground}" Height="591" Width="749">
                                     <Grid Grid.Row="2" Margin="10,5,5,5" MinWidth="330" IsEnabled="{Binding Path=DarwinDatabase, Converter={StaticResource NullConverter}}">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*"/>

--- a/src/Darwin.Wpf/TraceWindow.xaml
+++ b/src/Darwin.Wpf/TraceWindow.xaml
@@ -299,7 +299,7 @@ along with DARWIN.  If not, see https://www.gnu.org/licenses/
                                 <!-- PointSize is determined by dividing a constant by ZoomRatio -->
                                 <fe:PointVisuals Width="{Binding Path=ActualWidth, ElementName=TraceImage}" Height="{Binding Path=ActualHeight, ElementName=TraceImage}"
                                             Background="Transparent"
-                                            PointSize="{Binding Path=ZoomRatio}"
+                                            PointSize="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}, Path=OriginalZoomRatio}"
                                             ContourScale="{Binding Contour.Scale}"
                                             ItemsSource="{Binding Contour.Points}"
                                             Brushes="{StaticResource brushes}" />

--- a/src/Darwin.Wpf/TraceWindow.xaml
+++ b/src/Darwin.Wpf/TraceWindow.xaml
@@ -294,16 +294,17 @@ along with DARWIN.  If not, see https://www.gnu.org/licenses/
                                     </Image.LayoutTransform>
                                 </Image>
                                 
-                                <!-- This is for the contour/outline feature points -->
-                                <fe:PointVisuals Width="{Binding Path=ActualWidth, ElementName=TraceImage}" Height="{Binding Path=ActualHeight, ElementName=TraceImage}"
+                                <!-- This is for the contour/outline points -->
+                                <!-- PointSize is determined by dividing a constant by ZoomRatio -->
+                                <fe:PointVisuals Width="{Binding Path=Width, ElementName=TraceImage}" Height="{Binding Path=Height, ElementName=TraceImage}"
                                             Background="Transparent"
-                                            PointSize="3"
+                                            PointSize="{Binding Path=ZoomRatio}"
                                             ContourScale="{Binding Contour.Scale}"
                                             ItemsSource="{Binding Contour.Points}"
                                             Brushes="{StaticResource brushes}" />
                                 
                                 <!-- This control is for independent x/y feature points like the eye -->
-                                <fe:CoordinatePointVisuals Visibility="{Binding FeatureToolsVisibility}" Width="{Binding Path=ActualWidth, ElementName=TraceImage}" Height="{Binding Path=ActualHeight, ElementName=TraceImage}"
+                                <fe:CoordinatePointVisuals Visibility="{Binding FeatureToolsVisibility}" Width="{Binding Path=Width, ElementName=TraceImage}" Height="{Binding Path=Height, ElementName=TraceImage}"
                                             PointSize="3" FeaturePointSize="3"
                                             ContourScale="{Binding Contour.Scale}"
                                             ItemsSource="{Binding CoordinateFeaturePoints}"

--- a/src/Darwin.Wpf/TraceWindow.xaml
+++ b/src/Darwin.Wpf/TraceWindow.xaml
@@ -16,7 +16,8 @@ You should have received a copy of the GNU General Public License
 along with DARWIN.  If not, see https://www.gnu.org/licenses/
 -->
 
-<Window x:Class="Darwin.Wpf.TraceWindow"
+<Window x:Name="TraceWin"
+        x:Class="Darwin.Wpf.TraceWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -296,7 +297,7 @@ along with DARWIN.  If not, see https://www.gnu.org/licenses/
                                 
                                 <!-- This is for the contour/outline points -->
                                 <!-- PointSize is determined by dividing a constant by ZoomRatio -->
-                                <fe:PointVisuals Width="{Binding Path=Width, ElementName=TraceImage}" Height="{Binding Path=Height, ElementName=TraceImage}"
+                                <fe:PointVisuals Width="{Binding Path=ActualWidth, ElementName=TraceImage}" Height="{Binding Path=ActualHeight, ElementName=TraceImage}"
                                             Background="Transparent"
                                             PointSize="{Binding Path=ZoomRatio}"
                                             ContourScale="{Binding Contour.Scale}"

--- a/src/Darwin.Wpf/TraceWindow.xaml
+++ b/src/Darwin.Wpf/TraceWindow.xaml
@@ -304,7 +304,7 @@ along with DARWIN.  If not, see https://www.gnu.org/licenses/
                                             Brushes="{StaticResource brushes}" />
                                 
                                 <!-- This control is for independent x/y feature points like the eye -->
-                                <fe:CoordinatePointVisuals Visibility="{Binding FeatureToolsVisibility}" Width="{Binding Path=Width, ElementName=TraceImage}" Height="{Binding Path=Height, ElementName=TraceImage}"
+                                <fe:CoordinatePointVisuals Visibility="{Binding FeatureToolsVisibility}" Width="{Binding Path=ActualWidth, ElementName=TraceImage}" Height="{Binding Path=ActualHeight, ElementName=TraceImage}"
                                             PointSize="3" FeaturePointSize="3"
                                             ContourScale="{Binding Contour.Scale}"
                                             ItemsSource="{Binding CoordinateFeaturePoints}"

--- a/src/Darwin.Wpf/TraceWindow.xaml
+++ b/src/Darwin.Wpf/TraceWindow.xaml
@@ -296,7 +296,7 @@ along with DARWIN.  If not, see https://www.gnu.org/licenses/
                                 </Image>
                                 
                                 <!-- This is for the contour/outline points -->
-                                <!-- PointSize is determined by dividing a constant by ZoomRatio -->
+                                <!-- PointSize is determined by dividing a constant by OriginalZoomRatio from TraceWindow.xaml.cs-->
                                 <fe:PointVisuals Width="{Binding Path=ActualWidth, ElementName=TraceImage}" Height="{Binding Path=ActualHeight, ElementName=TraceImage}"
                                             Background="Transparent"
                                             PointSize="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}, Path=OriginalZoomRatio}"

--- a/src/Darwin.Wpf/TraceWindow.xaml.cs
+++ b/src/Darwin.Wpf/TraceWindow.xaml.cs
@@ -49,11 +49,11 @@ using System.Xml.Schema;
 
 namespace Darwin.Wpf
 {
-    /// <summary>
-    /// Interaction logic for TraceWindow.xaml
-    /// </summary>
-    public partial class TraceWindow : Window
-    {
+	/// <summary>
+	/// Interaction logic for TraceWindow.xaml
+	/// </summary>
+	public partial class TraceWindow : Window
+	{
 		private const int ImagePadding = 20;
 		private const string NoTraceErrorMessageDatabase = "You must trace your image before it can be added to the database.";
 		private const string NoIDErrorMessage = "You must enter an ID Code before\nyou can add a {0} to the database.";
@@ -81,7 +81,7 @@ namespace Darwin.Wpf
 		private string _previousStatusBarMessage;
 
 		private FeaturePointType _moveFeature;
-        private bool _moveFeatureUseCoordinate;
+		private bool _moveFeatureUseCoordinate;
 		private CoordinateFeaturePoint _moveCoordinateFeature;
 
 		private TraceWindowViewModel _vm;
@@ -96,15 +96,15 @@ namespace Darwin.Wpf
 			_vm = vm;
 
 			if (_vm.TraceLocked)
-            {
-                _vm.TraceTool = TraceToolType.MoveFeature;
-                _vm.TraceStep = TraceStepType.IdentifyFeatures;
-            }
+			{
+				_vm.TraceTool = TraceToolType.MoveFeature;
+				_vm.TraceStep = TraceStepType.IdentifyFeatures;
+			}
 
 			if (_vm.ViewerMode)
-            {
+			{
 				_vm.TraceTool = TraceToolType.Hand;
-            }
+			}
 
 			_vm.ZoomValues.Add(16);
 			_vm.ZoomValues.Add(8);
@@ -402,6 +402,29 @@ namespace Darwin.Wpf
 				_vm.StatusBarMessage = "Make any Needed Corrections to Outline Trace using Tools Above";
 
 			} //102AT
+		}
+
+
+		private double _originalZoomRatio()
+        {
+			double
+				widthRatio = TraceScrollViewer.ActualWidth / (_vm.OriginalBitmap.Width + ImagePadding),
+				heightRatio = TraceScrollViewer.ActualHeight / (_vm.OriginalBitmap.Height + ImagePadding);
+			if (widthRatio < heightRatio)
+            {
+				// the width is the restrictive dimension
+				return (double)Math.Round(widthRatio, 2);
+            }
+			else
+            {
+				return (double)Math.Round(heightRatio, 2);
+            }
+        }
+
+
+		public double OriginalZoomRatio
+		{
+			get { return _originalZoomRatio(); }
 		}
 
 

--- a/src/Darwin.Wpf/TraceWindow.xaml.cs
+++ b/src/Darwin.Wpf/TraceWindow.xaml.cs
@@ -404,6 +404,7 @@ namespace Darwin.Wpf
 			} //102AT
 		}
 
+
 		// TODO: Do we really need this, or is this not ported correctly?
 		private void GetViewedImageBoundsNonZoomed(out int left, out int top, out int right, out int bottom)
 		{

--- a/src/Darwin.Wpf/ViewModel/TraceWindowViewModel.cs
+++ b/src/Darwin.Wpf/ViewModel/TraceWindowViewModel.cs
@@ -40,6 +40,7 @@ namespace Darwin.Wpf.ViewModel
 		public event PropertyChangedEventHandler PropertyChanged;
 
 		private string _windowTitle;
+
 		public string WindowTitle
 		{
 			get


### PR DESCRIPTION
Changes the binding of PointSize so points are scaled to image resolution, but are not affected later by modifying the outline at a greater or lesser zoom factor